### PR TITLE
Add drives subsites and sync user permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,11 @@
 This connector synchronizes and enables searching over following items:
 
 * Site collections
-* Sites in a collection
-* Lists 
-* Items
+* Sites and sub sites
+* Lists
+* Items (List items)
 * Attachments
-
-Support for following items expected in the upcoming versions:
-
-* Sub-sites
-* Drives
+* Drives items (files and folders)
 
 If you have a multi-tenant environment, you need to configure one connector instance for each of the tenants / web-applications.
 
@@ -49,15 +45,45 @@ Required fields in the configuration file:
 
 The remaining parameters are optional and have a default value.
 
+## Running the Connector ##
+
+### Running a specific functionality as a daemon process ###
+
+To run any specific functionality as a daemon process, execute the following command:
+```bash
+python3 filename.py >/dev/null 2>&1 &
+```
+For example, if you want to run indexing functionality as a daemon process, simply execute the following command:
+```bash
+python3 fetch_index.py >/dev/null 2>&1 &
+```
+
+### Running multiple functionalities as a daemon process ###
+
+To run the connector with multiple functionalies as a daemon process, execute the following shell script command:
+```bash
+sh runner.sh >/dev/null 2>&1 &
+```
+This command will run all the functionalities (full sync, indexing documents, deindexing documents, indexing permissions) parallelly. 
+
 ## Indexing ##
 
 You are all set to begin synchronizing document to Workplace Search. Run the python file _fetch_index.py_. The file will run in intervals and ingest the data from SharePoint Server 2016.
 
-If the permission fetching is enabled in the configuration file, fetch_index also handles permission fetching from the SharePoint server and ingests the documents with document level permissions. This would replicate document permissions from SharePoint Server to Workplace Search.
+If the permission fetching is enabled in the configuration file, fetch_index also handles document level permission fetching from the SharePoint server and ingests the documents with document level permissions. This would replicate document permissions from SharePoint Server to Workplace Search.
+The connector has two modes for indexing: incremental and fullsync.
+The default mode is incremental sync.
+Fullsync on the other hand, ensures indexing occurs from the _start_time_ provided in the configuration file till the current time of execution. To run fullsync, execute the python file _full_sync.py_.
+
+Note: Indexing of all the sub sites is guaranteed only in fullsync and not in incremental sync due to an issue in SharePoint, i.e. the parent site does not get updated whenever a subsite inside it is modified. Hence, if we create/modify a sub site, the last updated time of parent site is not altered.
+
+## Sync user permissions ##
+
+This functionality will sync any updates to the users and groups in the Sharepoint with Workplace
 
 ## De-Indexing ##
 
-When items are deleted from SharePoint, a separate process is required to update Workplace Search accordingly. Run the deindex.py file for deleting the records from Workplace Search.
+When items are deleted from SharePoint, a separate process is required to update Workplace Search accordingly. Run the _deindex.py_ file for deleting the records from Workplace Search.
 
 ## Testing ##
 

--- a/adapter.py
+++ b/adapter.py
@@ -13,10 +13,16 @@ DEFAULT_SCHEMA = {
         'relative_url': 'ParentWebUrl',
         'title': 'Title'
     },
-    'items': {
+    'list_items': {
         'title': 'Title',
         'id': 'GUID',
         'created_at': 'Created',
         'author_id': 'AuthorId'
+    },
+    'drive_items': {
+        'title': 'Name',
+        'id': 'GUID',
+        'created_at': 'TimeCreated',
+        'last_updated': 'TimeLastModified'
     }
 }

--- a/deindex.py
+++ b/deindex.py
@@ -22,16 +22,16 @@ class Deindex:
         self.sharepoint_client = SharePoint(logger)
         self.ws_client = WorkplaceSearch(self.ws_host, http_auth=self.ws_token)
 
-    def deindexing_items(self, collection, ids):
+    def deindexing_items(self, collection, ids, key):
         """Fetches the id's of deleted items from the sharepoint server and
            invokes delete documents api for those ids to remove them from
            workplace search
         """
-        delete_ids_items = ids["delete_keys"][collection].get("list_items")
+        delete_ids_items = ids["delete_keys"][collection].get(key)
         logger.info("Deindexing items...")
         if delete_ids_items:
             delete_site = []
-            global_ids_items = ids["global_keys"][collection]["list_items"]
+            global_ids_items = ids["global_keys"][collection][key]
             for site_url, item_details in delete_ids_items.items():
                 delete_list = []
                 for list_name, items in item_details.items():
@@ -65,7 +65,7 @@ class Deindex:
             for site_url in delete_site:
                 global_ids_items.pop(site_url)
         else:
-            logger.info("No list-items found to be deleted for collection: %s" % collection)
+            logger.info("No list-items or drive-items found to be deleted for collection: %s" % collection)
         return ids
 
     def deindexing_lists(self, collection, ids):
@@ -145,7 +145,8 @@ def start():
                 if ids["delete_keys"].get(collection):
                     ids = deindexer.deindexing_sites(collection, ids)
                     ids = deindexer.deindexing_lists(collection, ids)
-                    ids = deindexer.deindexing_items(collection, ids)
+                    ids = deindexer.deindexing_items(collection, ids, "list_items")
+                    ids = deindexer.deindexing_items(collection, ids, "drive_items")
                 else:
                     logger.info("No objects present to be deleted for the collection: %s" % collection)
             ids["delete_keys"] = {}

--- a/deindex.py
+++ b/deindex.py
@@ -2,7 +2,6 @@ import time
 import json
 import requests
 import os
-from sharepoint_utils import encode
 from elastic_enterprise_search import WorkplaceSearch
 from sharepoint_client import SharePoint
 from configuration import Configuration
@@ -34,10 +33,10 @@ class Deindex:
             global_ids_items = ids["global_keys"][collection][key]
             for site_url, item_details in delete_ids_items.items():
                 delete_list = []
-                for list_name, items in item_details.items():
+                for list_id, items in item_details.items():
                     doc = []
                     for item_id in items:
-                        url = f"{self.sharepoint_host}{site_url}/_api/web/lists/getbytitle(\'{encode(list_name)}\')/items"
+                        url = f"{self.sharepoint_host}{site_url}/_api/web/lists(guid\'{list_id}\')/items"
                         resp = self.sharepoint_client.get(
                             url, f"?$filter= GUID eq  \'{item_id}\'", "deindex")
                         if resp:
@@ -50,22 +49,22 @@ class Deindex:
                             http_auth=self.ws_token,
                             content_source_id=self.ws_source,
                             document_ids=doc)
-                    updated_items = global_ids_items[site_url].get(list_name)
+                    updated_items = global_ids_items[site_url].get(list_id)
                     if updated_items is None:
                         continue
                     for id in doc:
                         if id in updated_items:
                             updated_items.remove(id)
                     if updated_items == []:
-                        delete_list.append(list_name)
-                for list_name in delete_list:
-                    global_ids_items[site_url].pop(list_name)
+                        delete_list.append(list_id)
+                for list_id in delete_list:
+                    global_ids_items[site_url].pop(list_id)
                 if global_ids_items[site_url] == {}:
                     delete_site.append(site_url)
             for site_url in delete_site:
                 global_ids_items.pop(site_url)
         else:
-            logger.info("No list-items or drive-items found to be deleted for collection: %s" % collection)
+            logger.info("No %s found to be deleted for collection: %s" % (key, collection))
         return ids
 
     def deindexing_lists(self, collection, ids):
@@ -82,10 +81,10 @@ class Deindex:
             global_ids_lists = ids["global_keys"][collection]["lists"]
             for site_url, list_details in delete_ids_lists.items():
                 doc = []
-                for list_id, list_name in list_details.items():
-                    url = f"{self.sharepoint_host}{site_url}/_api/web/lists/getbytitle(\'{encode(list_name)}\')"
+                for list_id in list_details.keys():
+                    url = f"{self.sharepoint_host}{site_url}/_api/web/lists(guid\'{list_id}\')"
                     resp = self.sharepoint_client.get(url, '', "deindex")
-                    if resp.status_code == requests.codes['not_found']:
+                    if resp and resp.status_code == requests.codes['not_found']:
                         doc.append(list_id)
                 self.ws_client.delete_documents(
                     http_auth=self.ws_token,
@@ -114,7 +113,7 @@ class Deindex:
             for site_id, site_url in site_details.items():
                 url = f"{self.sharepoint_host}{site_url}/_api/web"
                 resp = self.sharepoint_client.get(url, '', "deindex")
-                if resp.status_code == requests.codes['not_found']:
+                if resp and resp.status_code == requests.codes['not_found']:
                     doc.append(site_id)
             self.ws_client.delete_documents(
                 http_auth=self.ws_token,

--- a/fetch_index.py
+++ b/fetch_index.py
@@ -11,6 +11,7 @@ from configuration import Configuration
 import logger_manager as log
 from usergroup_permissions import Permissions
 from datetime import datetime
+from dateutil.parser import parse
 import os
 import json
 from tika.tika import TikaException
@@ -26,7 +27,8 @@ LIST = "list"
 ITEM = "item"
 SITES = "sites"
 LISTS = "lists"
-ITEMS = "items"
+ITEMS = "list_items"
+DRIVES = "drive_items"
 DOCUMENT_SIZE = 100
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -36,7 +38,7 @@ def check_response(response, error_message, exception_message, param_name):
         :param response: response from the sharepoint client
         :param error_message: error message if not getting the response
         :param exception message: exception message
-        :param param_name: parameter name whether it is SITES, LISTS OR ITEMS
+        :param param_name: parameter name whether it is SITES, LISTS, ITEMS OR DRIVES
         Returns:
             response_data: response received from invoking
     """
@@ -103,12 +105,13 @@ class FetchIndex:
 
     def get_schema_fields(self, document_name):
         """ returns the schema of all the include_fields or exclude_fields specified in the configuration file.
-            :param document_name: document name from 'sites', 'lists' or 'items'
+            :param document_name: document name from SITES, LISTS, ITEMS OR DRIVES
             Returns:
                 schema: included and excluded fields schema
         """
         fields = self.objects.get(document_name)
         adapter_schema = adapter.DEFAULT_SCHEMA[document_name]
+        field_id = adapter_schema['id']
         if fields:
             include_fields = fields.get("include_fields")
             exclude_fields = fields.get("exclude_fields")
@@ -116,20 +119,22 @@ class FetchIndex:
                 adapter_schema = {key: val for key, val in adapter_schema.items() if val in include_fields}
             elif exclude_fields:
                 adapter_schema = {key: val for key, val in adapter_schema.items() if val not in exclude_fields}
-            adapter_schema["id"] = "GUID" if document_name == ITEMS else "Id"
+            adapter_schema['id'] = field_id
         return adapter_schema
 
-    def index_sites(self, collection, ids, index):
+    def index_sites(self, parent_site_url, sites, ids, index):
         """This method fetches sites from a collection and invokes the
             index permission method to get the document level permissions.
             If the fetching is not successful, it logs proper message.
-            :param collection: collection name
+            :param parent_site_url: parent site relative path
+            :param sites: dictionary of site path and it's last updated time
+            :param ids: structure containing id's of all objects
             :param index: index, boolean value
             Returns:
                 document: response of sharepoint GET call, with fields specified in the schema
         """
         rel_url = urljoin(
-            self.sharepoint_host, f"/sites/{collection}/_api/web/webs"
+            self.sharepoint_host, f"{parent_site_url}/_api/web/webs"
         )
         logger.info("Fetching the sites detail from url: %s" % (rel_url))
         query = self.sharepoint_client.get_query(
@@ -144,8 +149,8 @@ class FetchIndex:
             SITES,
         )
         if not response_data:
-            logger.info("No sites were created for this interval: start time: %s and end time: %s" % (self.start_time, self.end_time))
-            return []
+            logger.info("No sites were created in %s for this interval: start time: %s and end time: %s" % (parent_site_url, self.start_time, self.end_time))
+            return sites
         logger.info(
             "Successfuly fetched and parsed %s sites response from SharePoint" % len(response_data)
         )
@@ -160,24 +165,24 @@ class FetchIndex:
                 # need to convert date to iso else workplace search throws error on date format Invalid field value: Value '2021-09-29T08:13:00' cannot be parsed as a date (RFC 3339)"]}
                 response_data[num]['Created'] += 'Z'
                 for field, response_field in schema.items():
-                    doc[field] = response_data[num].get(response_field, None)
+                    doc[field] = response_data[num].get(response_field)
                 if self.enable_permission is True:
                     doc["_allow_permissions"] = self.index_permissions(
                         key=SITES, site=response_data[num]['ServerRelativeUrl'])
                 document.append(doc)
                 ids["sites"].update({doc["id"]: response_data[num]["ServerRelativeUrl"]})
-
-            self.index_document(document, collection, SITES)
-        sites = []
+            self.index_document(document, parent_site_url, SITES)
         for result in response_data:
-            sites.append(result.get("ServerRelativeUrl"))
+            site_server_url = result.get("ServerRelativeUrl")
+            sites.update({site_server_url: result.get("LastItemModifiedDate")})
+            self.index_sites(site_server_url, sites, ids, index)
         return sites
 
     def index_lists(self, sites, ids, index):
         """This method fetches lists from all sites in a collection and invokes the
             index permission method to get the document level permissions.
             If the fetching is not successful, it logs proper message.
-            :param sites: site lists
+            :param sites: dictionary of site path and it's last updated time
             :param index: index, boolean value
             Returns:
                 document: response of sharepoint GET call, with fields specified in the schema
@@ -187,8 +192,10 @@ class FetchIndex:
         document = []
         if not sites:
             logger.info("No list was created in this interval: start time: %s and end time: %s" % (self.start_time, self.end_time))
-            return []
-        for site in sites:
+            return [], []
+        for site, time_modified in sites.items():
+            if parse(self.start_time) > parse(time_modified):
+                continue
             rel_url = urljoin(self.sharepoint_host, f"{site}/_api/web/lists")
             logger.info(
                 "Fetching the lists for site: %s from url: %s"
@@ -219,12 +226,13 @@ class FetchIndex:
             schema_list = self.get_schema_fields(LISTS)
 
             if index:
-                ids["lists"].update({site: {}})
+                if not ids["lists"].get(site):
+                    ids["lists"].update({site: {}})
                 for num in range(len(response_data)):
                     doc = {'type': LIST}
                     for field, response_field in schema_list.items():
                         doc[field] = response_data[num].get(
-                            response_field, None)
+                            response_field)
                     if self.enable_permission is True:
                         doc["_allow_permissions"] = self.index_permissions(
                             key=LISTS, site=site, list_name=response_data[num]['Title'], list_url=response_data[num]['ParentWebUrl'], itemid=None)
@@ -240,18 +248,22 @@ class FetchIndex:
 
             responses.append(response_data)
         lists = {}
+        libraries = {}
         for response in responses:
             for result in response:
-                lists[result.get("Id")] = [result.get(
-                    "ParentWebUrl"), result.get("Title")]
-        return lists
+                if result.get('BaseType') == 1:
+                    libraries[result.get("Id")] = [result.get(
+                        "ParentWebUrl"), result.get("Title"), result.get("LastItemModifiedDate")]
+                else:
+                    lists[result.get("Id")] = [result.get(
+                        "ParentWebUrl"), result.get("Title"), result.get("LastItemModifiedDate")]
+        return lists, libraries
 
-    def index_items(self, lists, ids, index):
+    def index_items(self, lists, ids):
         """This method fetches items from all the lists in a collection and
             invokes theindex permission method to get the document level permissions.
             If the fetching is not successful, it logs proper message.
             :param lists: document lists
-            :param index: index, boolean value
             Returns:
                 document: response of sharepoint GET call, with fields specified in the schema
         """
@@ -262,8 +274,11 @@ class FetchIndex:
             logger.info("No item was created in this interval: start time: %s and end time: %s" % (self.start_time, self.end_time))
             return []
         for value in lists.values():
-            ids["list_items"].update({value[0]: {}})
+            if not ids["list_items"].get(value[0]):
+                ids["list_items"].update({value[0]: {}})
         for list_content, value in lists.items():
+            if parse(self.start_time) > parse(value[2]):
+                continue
             rel_url = urljoin(
                 self.sharepoint_host,
                 f"{value[0]}/_api/web/lists/getbytitle('{encode(value[1])}')/items",
@@ -297,55 +312,135 @@ class FetchIndex:
                                     f"{value[0]}/Lists/{list_name}/DispForm.aspx?ID=")
             schema_item = self.get_schema_fields(ITEMS)
             document = []
-
-            if index:
-
+            if not ids["list_items"][value[0]].get(value[1]):
                 ids["list_items"][value[0]].update({value[1]: []})
-                rel_url = urljoin(
-                    self.sharepoint_host, f'{value[0]}/_api/web/lists/getbytitle(\'{encode(value[1])}\')/items?$select=Attachments,AttachmentFiles,Title&$expand=AttachmentFiles')
+            rel_url = urljoin(
+                self.sharepoint_host, f'{value[0]}/_api/web/lists/getbytitle(\'{encode(value[1])}\')/items?$select=Attachments,AttachmentFiles,Title&$expand=AttachmentFiles')
 
-                new_query = "&" + query.split("?")[1]
-                file_response = self.sharepoint_client.get(rel_url, query=new_query, param_name="attachment")
-                file_response = file_response.json()
-                file_response_data = check_response(file_response, "No attachments were found at url %s in the interval: start time: %s and end time: %s" % (
-                    rel_url, self.start_time, self.end_time), "Error while parsing file response for file at url %s." % (rel_url), "attachment")
+            new_query = "&" + query.split("?")[1]
+            file_response = self.sharepoint_client.get(rel_url, query=new_query, param_name="attachment")
+            file_response = file_response.json()
+            file_response_data = check_response(file_response, "No attachments were found at url %s in the interval: start time: %s and end time: %s" % (
+                rel_url, self.start_time, self.end_time), "Error while parsing file response for file at url %s." % (rel_url), "attachment")
 
-                for num in range(len(response_data)):
-                    doc = {'type': ITEM}
-                    if response_data[num].get('Attachments'):
-                        for data in file_response_data:
-                            if response_data[num].get('Title') == data['Title']:
-                                file_relative_url = data[
-                                    'AttachmentFiles']['results'][0]['ServerRelativeUrl']
-                                url_s = f"{value[0]}/_api/web/GetFileByServerRelativeUrl(\'{file_relative_url}\')/$value"
-                                response = self.sharepoint_client.get(
-                                    urljoin(self.sharepoint_host, url_s), query='', param_name="attachment")
-                                if response.status_code == requests.codes.ok:
-                                    try:
-                                        doc['body'] = extract(response.content)
-                                    except TikaException as exception:
-                                        logger.error('Error while extracting the contents from the attachment, Error %s' % (exception))
-                                        doc['body'] = {}
-                                break
-                    for field, response_field in schema_item.items():
-                        doc[field] = response_data[num].get(
-                            response_field, None)
-                    if self.enable_permission is True:
-                        doc["_allow_permissions"] = self.index_permissions(
-                            key=ITEMS, list_name=value[1], list_url=value[0], itemid=str(response_data[num]["Id"]))
-                    doc["url"] = base_item_url + str(response_data[num]["Id"])
-                    document.append(doc)
+            for num in range(len(response_data)):
+                doc = {'type': ITEM}
+                if response_data[num].get('Attachments'):
+                    for data in file_response_data:
+                        if response_data[num].get('Title') == data['Title']:
+                            file_relative_url = data[
+                                'AttachmentFiles']['results'][0]['ServerRelativeUrl']
+                            url_s = f"{value[0]}/_api/web/GetFileByServerRelativeUrl(\'{encode(file_relative_url)}\')/$value"
+                            response = self.sharepoint_client.get(
+                                urljoin(self.sharepoint_host, url_s), query='', param_name="attachment")
+                            if response.status_code == requests.codes.ok:
+                                try:
+                                    doc['body'] = extract(response.content)
+                                except TikaException as exception:
+                                    logger.error('Error while extracting the contents from the attachment, Error %s' % (exception))
+                                    doc['body'] = {}
+                            break
+                for field, response_field in schema_item.items():
+                    doc[field] = response_data[num].get(
+                        response_field)
+                if self.enable_permission is True:
+                    doc["_allow_permissions"] = self.index_permissions(
+                        key=ITEMS, list_name=value[1], list_url=value[0], itemid=str(response_data[num]["Id"]))
+                doc["url"] = base_item_url + str(response_data[num]["Id"])
+                document.append(doc)
+                if response_data[num].get("GUID") not in ids["list_items"][value[0]][value[1]]:
                     ids["list_items"][value[0]][value[1]].append(
                         response_data[num].get("GUID"))
-                logger.info(
-                    "Indexing the listitem for list: %s to the Workplace"
-                    % (value[1])
-                )
+            logger.info(
+                "Indexing the listitem for list: %s to the Workplace"
+                % (value[1])
+            )
 
-                self.index_document(document, value[1], ITEMS)
+            self.index_document(document, value[1], ITEMS)
 
             responses.append(document)
         return responses
+
+    def index_drive_items(self, libraries, ids):
+        """This method fetches items from all the lists in a collection and
+            invokes theindex permission method to get the document level permissions.
+            If the fetching is not successful, it logs proper message.
+            :param libraries: document lists
+            :param ids: structure containing id's of all objects
+        """
+        #  here value is a list of url and title of the library
+        logger.info("Fetching all the files for the library")
+        if not libraries:
+            logger.info("No file was created in this interval: start time: %s and end time: %s" % (self.start_time, self.end_time))
+            return []
+        for lib_content, value in libraries.items():
+            if parse(self.start_time) > parse(value[2]):
+                continue
+            if not ids["drive_items"].get(value[0]):
+                ids["drive_items"].update({value[0]: {}})
+            rel_url = urljoin(
+                self.sharepoint_host,
+                f"{value[0]}/_api/web/lists/getbytitle('{encode(value[1])}')/items?$select=Modified,Id,GUID,File,Folder&$expand=File,Folder",
+            )
+            logger.info(
+                "Fetching the items for libraries: %s from url: %s"
+                % (value[1], rel_url)
+            )
+            query = self.sharepoint_client.get_query(
+                self.start_time, self.end_time, DRIVES)
+            response = self.sharepoint_client.get(rel_url, query, DRIVES)
+            response_data = check_response(
+                response,
+                "Could not fetch the items for library: %s" % (value[1]),
+                "Error while parsing the get items response for library: %s from url: %s."
+                % (value[1], rel_url),
+                DRIVES,
+            )
+            if not response_data:
+                logger.info("No item was created for the library %s in this interval: start time: %s and end time: %s" % (value[1], self.start_time, self.end_time))
+                continue
+            logger.info(
+                "Successfuly fetched and parsed %s drive item response for library: %s from SharePoint"
+                % (len(response_data), value[1])
+            )
+            schema_drive = self.get_schema_fields(DRIVES)
+            document = []
+            if not ids["drive_items"][value[0]].get(value[1]):
+                ids["drive_items"][value[0]].update({value[1]: []})
+            for num in range(len(response_data)):
+                if response_data[num]['File'].get('TimeLastModified'):
+                    obj_type = 'File'
+                    doc = {'type': "file"}
+                    file_relative_url = response_data[num]['File']['ServerRelativeUrl']
+                    url_s = f"{value[0]}/_api/web/GetFileByServerRelativeUrl(\'{encode(file_relative_url)}\')/$value"
+                    response = self.sharepoint_client.get(
+                        urljoin(self.sharepoint_host, url_s), query='', param_name="attachment")
+                    if response.status_code == requests.codes.ok:
+                        try:
+                            doc['body'] = extract(response.content)
+                        except TikaException as exception:
+                            logger.error('Error while extracting the contents from the file at %s, Error %s' % (response_data[num].get('Url'), exception))
+                            doc['body'] = {}
+                else:
+                    obj_type = 'Folder'
+                    doc = {'type': "folder"}
+                for field, response_field in schema_drive.items():
+                    doc[field] = response_data[num][obj_type].get(
+                        response_field)
+                doc['id'] = response_data[num].get("GUID")
+                if self.enable_permission is True:
+                    doc["_allow_permissions"] = self.index_permissions(
+                        key=DRIVES, list_name=value[1], list_url=value[0], itemid=str(response_data[num].get("ID")))
+                doc["url"] = urljoin(self.sharepoint_host, response_data[num][obj_type]["ServerRelativeUrl"])
+                document.append(doc)
+                if doc['id'] not in ids["drive_items"][value[0]][value[1]]:
+                    ids["drive_items"][value[0]][value[1]].append(doc['id'])
+            if document:
+                logger.info("Indexing the drive items for library: %s to the Workplace" % (value[1]))
+                self.index_document(document, value[1], DRIVES)
+            else:
+                logger.info("No item was present in the library %s for the interval: start time: %s and end time: %s" % (
+                    value[1], self.start_time, self.end_time))
 
     def get_roles(self, key, site, list_url, list_name, itemid):
         """ Checks the permissions and returns the user roles.
@@ -367,12 +462,11 @@ class FetchIndex:
                 key, rel_url, title=list_name
             )
 
-        elif key == ITEMS:
+        else:
             rel_url = urljoin(self.sharepoint_host, list_url)
             roles = self.permissions.fetch_users(
                 key, rel_url, title=list_name, id=itemid
             )
-
         return roles, rel_url
 
     def index_permissions(
@@ -408,45 +502,57 @@ class FetchIndex:
             groups.append(title)
         return groups
 
-    def indexing(self, collection, ids, storage, is_error_shared):
+    def indexing(self, collection, ids, storage, is_error_shared, job_type, parent_site_url, sites_path, lists_details, libraries_details):
         """This method fetches all the objects from sharepoint server and
             ingests them into the workplace search
             :param collection: collection name
             :param ids: id collection of the all the objects
             :param storage: temporary storage for storing all the documents
             :is_error_shared: list of all the is_error values
+            :job_type: denotes the type of sharepoint object being fetched in a particular process
+            :parent_site_url: parent site relative path
+            :sites_path: dictionary of site path and it's last updated time
+            :lists_details: dictionary containing list name, list path and id
+            :library_details: dictionary containing library name, library path and id
         """
+        if job_type == "sites":
+            sites = self.index_sites(parent_site_url, {}, ids, index=(SITES in self.objects))
+            sites_path.update(sites)
+        elif job_type == "lists":
+            if not self.is_error:
+                lists, libraries = self.index_lists(sites_path, ids, index=(LISTS in self.objects))
+                lists_details.update(lists)
+                libraries_details.update(libraries)
+        elif job_type == "list_items":
+            if ITEMS in self.objects and not self.is_error:
+                self.index_items(lists_details, ids)
+        else:
+            if DRIVES in self.objects and not self.is_error:
+                self.index_drive_items(libraries_details, ids)
 
-        sites = []
-        lists = {}
-        logger.info(
-            "Starting to index all the objects configured in the object field: %s"
-            % (str(self.objects))
-        )
-        sites = self.index_sites(collection, ids, index=(SITES in self.objects))
+            logger.info(
+                "Completed fetching all the objects for site collection: %s"
+                % (collection)
+            )
 
-        if not self.is_error:
-            lists = self.index_lists(sites, ids, index=(LISTS in self.objects))
-
-        if ITEMS in self.objects and not self.is_error:
-            self.index_items(lists, ids, index=True)
-
-        logger.info(
-            "Completed fetching all the objects for site collection: %s"
-            % (collection)
-        )
-
-        logger.info(
-            "Saving the checkpoint for the site collection: %s" % (collection)
-        )
-
+            logger.info(
+                "Saving the checkpoint for the site collection: %s" % (collection)
+            )
         is_error_shared.append(self.is_error)
         self.is_error = False
-        for obj in ['sites', 'lists', 'list_items']:
-            if ids.get(obj):
-                prev_ids = storage[obj]
-                prev_ids.update(ids[obj])
-                storage[obj] = prev_ids
+        if ids.get(job_type):
+            prev_ids = storage[job_type]
+            if job_type == 'sites':
+                prev_ids.update(ids[job_type])
+            elif job_type == "lists":
+                for site, list_content in ids[job_type].items():
+                    prev_ids[site] = {**prev_ids.get(site, {}), **ids[job_type][site]}
+            else:
+                for site, list_content in ids[job_type].items():
+                    prev_ids[site] = ids[job_type][site] if not prev_ids.get(site) else prev_ids[site]
+                    for list_name in list_content.keys():
+                        prev_ids[site][list_name] = list(set([*prev_ids[site].get(list_name, []), *ids[job_type][site][list_name]]))
+            storage[job_type] = prev_ids
 
 
 def datetime_partitioning(start_time, end_time, processes):
@@ -491,7 +597,7 @@ def start(indexing_type):
         storage_with_collection["delete_keys"] = copy.deepcopy(ids_collection.get("global_keys"))
 
         for collection in data.get("sharepoint.site_collections"):
-            storage = multiprocessing.Manager().dict({"sites": {}, "lists": {}, "list_items": {}})
+            storage = multiprocessing.Manager().dict({"sites": {}, "lists": {}, "list_items": {}, "drive_items": {}})
             logger.info(
                 "Starting the data fetching for site collection: %s"
                 % (collection)
@@ -517,11 +623,20 @@ def start(indexing_type):
             for sub in partitions:
                 datelist.append(sub.strftime(DATETIME_FORMAT))
 
-            jobs = []
+            jobs = {"sites": [], "lists": [], "list_items": [], "drive_items": []}
             if not ids_collection["global_keys"].get(collection):
                 ids_collection["global_keys"][collection] = {
-                    "sites": {}, "lists": {}, "list_items": {}}
+                    "sites": {}, "lists": {}, "list_items": {}, "drive_items": {}}
 
+            parent_site_url = f"/sites/{collection}"
+            sites_path = multiprocessing.Manager().dict()
+            sites_path.update({parent_site_url: end_time})
+            lists_details = multiprocessing.Manager().dict()
+            libraries_details = multiprocessing.Manager().dict()
+            logger.info(
+                "Starting to index all the objects configured in the object field: %s"
+                % (str(data.get("objects")))
+            )
             for num in range(0, worker_process):
                 start_time_partition = datelist[num]
                 end_time_partition = datelist[num + 1]
@@ -532,16 +647,15 @@ def start(indexing_type):
                 )
                 indexer = FetchIndex(
                     data, start_time_partition, end_time_partition)
+                for job_type, job_list in jobs.items():
+                    process = multiprocessing.Process(target=indexer.indexing, args=(collection, ids_collection["global_keys"][collection], storage, is_error_shared, job_type, parent_site_url, sites_path, lists_details, libraries_details))
+                    job_list.append(process)
 
-                process = multiprocessing.Process(target=indexer.indexing, args=(collection, ids_collection["global_keys"][collection], storage, is_error_shared, ))
-
-                jobs.append(process)
-
-            for job in jobs:
-                job.start()
-            for job in jobs:
-                job.join()
-
+            for job_list in jobs.values():
+                for job in job_list:
+                    job.start()
+                for job in job_list:
+                    job.join()
             storage_with_collection["global_keys"][collection] = storage.copy()
 
             if "True" in is_error_shared:

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,1 @@
+python3 fullsync.py & python3 fetch_index.py & python3 deindex.py & python3 sync_user_permissions.py

--- a/schema.py
+++ b/schema.py
@@ -162,6 +162,8 @@ schema = {
     },
     'worker_process': {
         'required': False,
-        'type': 'integer'
+        'type': 'integer',
+        'default': 40,
+        'min': 1
     }
 }

--- a/schema.py
+++ b/schema.py
@@ -76,7 +76,21 @@ schema = {
                         }
                     }
                 },
-            'items': {
+            'list_items': {
+                    'type': 'dict',
+                    'nullable': True,
+                    'schema': {
+                        'include_fields': {
+                            'nullable': True,
+                            'type': 'list'
+                        },
+                        'exclude_fields': {
+                            'nullable': True,
+                            'type': 'list'
+                        }
+                    }
+                },
+            'drive_items': {
                     'type': 'dict',
                     'nullable': True,
                     'schema': {

--- a/schema.py
+++ b/schema.py
@@ -124,6 +124,12 @@ schema = {
         'default': 2880,
         'min': 60
     },
+    'sync_permission_interval': {
+        'required': False,
+        'type': 'integer',
+        'default': 60,
+        'min': 1
+    },
     'log_level': {
         'required': False,
         'type': 'string',

--- a/sharepoint_client.py
+++ b/sharepoint_client.py
@@ -86,6 +86,7 @@ class SharePoint:
                         if retry < self.retry_count:
                             time.sleep(2 ** retry)
                         retry += 1
+                        paginate_query = None
                         continue
 
                 except RequestException as exception:
@@ -101,6 +102,8 @@ class SharePoint:
                     else:
                         return False
                     retry += 1
+        if retry > self.retry_count:
+            return response
         return response_list
 
     def get_query(self, start_time, end_time, param_name):

--- a/sharepoint_connector_config.yml
+++ b/sharepoint_connector_config.yml
@@ -37,6 +37,8 @@ end_time : "2021-08-31T13:58:12Z"
 indexing_interval: 60
 #The interval after which the connector looks for the deleted objects from SharePoint. The unit of the interval is minutes. By default, the interval is considered to be 60 minutes
 deletion_interval: 60
+#The interval after which the connector looks for new/updated user permissions from SharePoint. The unit of the interval is minutes. By default, the interval is considered to be 60 minutes
+sync_permission_interval: 60
 #The interval after which the connector fetches all the objects from sharepoint server from a given start_time in the configuration file to the current time
 full_sync_interval: 2880
 #The level of the logs the user wants to use in the log files. The possible values include: debug, info, warn, error. By default, the level is info

--- a/sharepoint_connector_config.yml
+++ b/sharepoint_connector_config.yml
@@ -46,6 +46,6 @@ log_level: info
 #The number of retries to perform in case of server error. The connector will use exponential backoff for retry mechanism
 retry_count: 3
 #Number of worker processes to be used for the connector. The ideal value should be equal to the number of CPU cores in the machine
-worker_process: 4
+worker_process: 40
 #the path of csv file containing mapping of sharepoint user ID to Workplace user ID
 sharepoint_workplace_user_mapping: "C:/Users/abc/folder_name/file_name.csv"

--- a/sharepoint_connector_config.yml
+++ b/sharepoint_connector_config.yml
@@ -28,7 +28,14 @@ objects:
         include_fields:
         exclude_fields:
     lists:
-    items:
+        include_fields:
+        exclude_fields:
+    list_items:
+        include_fields:
+        exclude_fields:
+    drive_items:
+        include_fields:
+        exclude_fields:
 #The time after which all the objects that are modified or created are fetched from Sharepoint. By default, all the objects present in the SharePoint till the end_time are fetched
 start_time : "2021-08-16T13:58:12Z"
 #The timestamp before which all the updated objects need to be fetched i.e. the connector won’t fetch any object updated/created after the end_time. By default, all the objects updated/added till the current time are fetched

--- a/sync_user_permissions.py
+++ b/sync_user_permissions.py
@@ -1,0 +1,140 @@
+import time
+from elastic_enterprise_search import WorkplaceSearch
+from checkpointing import Checkpoint
+from sharepoint_client import SharePoint
+from configuration import Configuration
+import logger_manager as log
+from usergroup_permissions import Permissions
+import os
+import csv
+from fetch_index import check_response
+
+logger = log.setup_logging("sharepoint_index_permissions")
+SITES = "sites"
+LISTS = "lists"
+ITEMS = "items"
+LISTITEMS = "list_items"
+
+
+class SyncUserPermission:
+    def __init__(self, data):
+        logger.info("Initializing the Permission Indexing class")
+        self.data = data
+        self.ws_host = data.get("enterprise_search.host_url")
+        self.ws_token = data.get("workplace_search.access_token")
+        self.ws_source = data.get("workplace_search.source_id")
+        self.sharepoint_host = data.get("sharepoint.host_url")
+        self.objects = data.get("objects")
+        self.site_collections = data.get("sharepoint.site_collections")
+        self.enable_permission = data.get("enable_document_permission")
+        self.checkpoint = Checkpoint(logger, data)
+        self.sharepoint_client = SharePoint(logger)
+        self.permissions = Permissions(logger, self.sharepoint_client)
+        self.ws_client = WorkplaceSearch(self.ws_host, http_auth=self.ws_token)
+        self.mapping_sheet_path = data.get("sharepoint_workplace_user_mapping")
+
+    def get_users_id(self):
+        """ This method returns the dictionary having the users as a key and it's unique id as a value
+        """
+        user_ids = {}
+        for collection in self.site_collections:
+            rel_url = f"{self.sharepoint_host}sites/{collection}/_api/web/siteusers"
+            response = self.sharepoint_client.get(rel_url, "?", "permission_users")
+            users = check_response(response.json(), "Could not fetch the SharePoint users.", "Error while parsing the response from url.", "sharepoint_users")
+            for user in users:
+                user_ids[user["Title"]] = user["Id"]
+        return user_ids
+
+    def get_user_groups(self, user_ids):
+        """ This method returns the groups of each user
+            :param user_ids: user ids to fetch the groups of the specific user
+        """
+        user_group = {}
+        for collection in self.site_collections:
+            rel_url = f"{self.sharepoint_host}sites/{collection}/"
+            for name, id in user_ids.items():
+                response = self.permissions.fetch_groups(rel_url, id)
+                groups = check_response(response.json(), "Could not fetch the SharePoint user groups.", "Error while parsing the response from url.", "user_groups")
+                user_group[name] = [group['Title'] for group in groups]
+        return user_group
+
+    def workplace_add_permission(self, permissions):
+        """ This method when invoked would index the permission provided in the paramater
+            for the user in paramter user_name
+            :param permissions: dictionary containing permissions of all the users
+        """
+        for user_name, permission_list in permissions.items():
+            try:
+                self.ws_client.add_user_permissions(
+                    content_source_id=self.ws_source,
+                    user=user_name,
+                    body={
+                        "permissions": permission_list
+                    },
+                )
+                logger.info(
+                    "Successfully indexed the permissions for user %s to the workplace" % (
+                        user_name
+                    )
+                )
+            except Exception as exception:
+                logger.exception(
+                    "Error while indexing the permissions for user: %s to the workplace. Error: %s" % (
+                        user_name, exception
+                    )
+                )
+
+    def sync_permissions(self):
+        """ This method when invoked, checks the permission of SharePoint users and update those user
+            permissions in the Workplace Search.
+        """
+        rows = {}
+        if (os.path.exists(self.mapping_sheet_path) and os.path.getsize(self.mapping_sheet_path) > 0):
+            with open(self.mapping_sheet_path) as file:
+                csvreader = csv.reader(file)
+                for row in csvreader:
+                    rows[row[0]] = row[1]
+
+        users = self.get_users_id()
+        user_names = {}
+        for user, id in users.items():
+            user_names.update({rows.get(user, user): id})
+        user_groups = self.get_user_groups(user_names)
+
+        # delete all the permissions present in workplace search
+        self.permissions.remove_all_permissions(data=self.data)
+
+        # add all the updated permissions
+        self.workplace_add_permission(user_groups)
+
+
+def start():
+    """ Runs the permission indexing logic regularly after a given interval
+        or puts the connector to sleep
+    """
+    logger.info("Starting the permission indexing..")
+    config = Configuration("sharepoint_connector_config.yml", logger)
+    data = config.configurations
+
+    while True:
+        enable_permission = data.get("enable_document_permission")
+        permission_indexer = SyncUserPermission(data)
+        if not enable_permission:
+            logger.info('Exiting as the enable permission flag is set to False')
+            exit(0)
+        permission_indexer.sync_permissions()
+
+        try:
+            sync_permission_interval = int(
+                data.get('sync_permission_interval'))
+        except Exception as exception:
+            logger.warn('Error while converting the parameter sync_permission_interval: %s to integer. Considering the default value as 60 minutes. Error: %s' % (
+                sync_permission_interval, exception))
+
+        # TODO: need to use schedule instead of time.sleep
+        logger.info('Sleeping..')
+        time.sleep(sync_permission_interval * 60)
+
+
+if __name__ == "__main__":
+    start()

--- a/usergroup_permissions.py
+++ b/usergroup_permissions.py
@@ -1,8 +1,8 @@
 from elastic_enterprise_search import WorkplaceSearch
 SITES = "sites"
 LISTS = "lists"
-ITEMS = "list_items"
-DRIVES = "drive_items"
+LIST_ITEMS = "list_items"
+DRIVE_ITEMS = "drive_items"
 
 
 class Permissions:
@@ -24,8 +24,8 @@ class Permissions:
         maps = {
             SITES: "_api/web/roleassignments?$expand=Member/users,RoleDefinitionBindings",
             LISTS: f"_api/web/lists(guid\'{list_id}\')/roleassignments?$expand=Member/users,RoleDefinitionBindings",
-            ITEMS: f"_api/web/lists(guid\'{list_id}\')/items({item_id})/roleassignments?$expand=Member/users,RoleDefinitionBindings",
-            DRIVES: f"_api/web/lists(guid\'{list_id}\')/items({item_id})/roleassignments?$expand=Member/users,RoleDefinitionBindings"
+            LIST_ITEMS: f"_api/web/lists(guid\'{list_id}\')/items({item_id})/roleassignments?$expand=Member/users,RoleDefinitionBindings",
+            DRIVE_ITEMS: f"_api/web/lists(guid\'{list_id}\')/items({item_id})/roleassignments?$expand=Member/users,RoleDefinitionBindings"
         }
         if not rel_url.endswith("/"):
             rel_url = rel_url + "/"

--- a/usergroup_permissions.py
+++ b/usergroup_permissions.py
@@ -1,4 +1,3 @@
-from sharepoint_utils import encode
 from elastic_enterprise_search import WorkplaceSearch
 SITES = "sites"
 LISTS = "lists"
@@ -12,21 +11,21 @@ class Permissions:
         self.sharepoint_client = sharepoint_client
         self.logger.info("Initilized Permissions class")
 
-    def fetch_users(self, key, rel_url, title="", id=""):
+    def fetch_users(self, key, rel_url, list_id="", item_id=""):
         """ Invokes GET calls to fetch unique permissions assigned to an object
             :param key: object key
             :param rel_url: relative url to the sharepoint farm
-            :param title: list title
-            :param id: item id
+            :param list_id: list guid
+            :param item_id: item id
             Returns:
                 Response of the GET call
         """
         self.logger.info("Fetching the user roles for key: %s" % (key))
         maps = {
             SITES: "_api/web/roleassignments?$expand=Member/users,RoleDefinitionBindings",
-            LISTS: f"_api/web/lists/getbytitle(\'{encode(title)}\')/roleassignments?$expand=Member/users,RoleDefinitionBindings",
-            ITEMS: f"_api/web/lists/getbytitle(\'{encode(title)}\')/items({id})/roleassignments?$expand=Member/users,RoleDefinitionBindings",
-            DRIVES: f"_api/web/lists/getbytitle(\'{encode(title)}\')/items({id})/roleassignments?$expand=Member/users,RoleDefinitionBindings"
+            LISTS: f"_api/web/lists(guid\'{list_id}\')/roleassignments?$expand=Member/users,RoleDefinitionBindings",
+            ITEMS: f"_api/web/lists(guid\'{list_id}\')/items({item_id})/roleassignments?$expand=Member/users,RoleDefinitionBindings",
+            DRIVES: f"_api/web/lists(guid\'{list_id}\')/items({item_id})/roleassignments?$expand=Member/users,RoleDefinitionBindings"
         }
         if not rel_url.endswith("/"):
             rel_url = rel_url + "/"
@@ -68,6 +67,5 @@ class Permissions:
             :param userid: user id for fetching the roles
         """
         self.logger.info("Fetching the group roles for userid: %s" % (userid))
-        response = self.sharepoint_client.get(
+        return self.sharepoint_client.get(
             rel_url, f"_api/web/GetUserById({userid})/groups", "permission_groups")
-        return response

--- a/usergroup_permissions.py
+++ b/usergroup_permissions.py
@@ -66,5 +66,6 @@ class Permissions:
             :param userid: user id for fetching the roles
         """
         self.logger.info("Fetching the group roles for userid: %s" % (userid))
-        self.sharepoint_client.get(
+        response = self.sharepoint_client.get(
             rel_url, f"_api/web/GetUserById({userid})/groups", "permission_groups")
+        return response

--- a/usergroup_permissions.py
+++ b/usergroup_permissions.py
@@ -2,7 +2,8 @@ from sharepoint_utils import encode
 from elastic_enterprise_search import WorkplaceSearch
 SITES = "sites"
 LISTS = "lists"
-ITEMS = "items"
+ITEMS = "list_items"
+DRIVES = "drive_items"
 
 
 class Permissions:
@@ -24,7 +25,8 @@ class Permissions:
         maps = {
             SITES: "_api/web/roleassignments?$expand=Member/users,RoleDefinitionBindings",
             LISTS: f"_api/web/lists/getbytitle(\'{encode(title)}\')/roleassignments?$expand=Member/users,RoleDefinitionBindings",
-            ITEMS: f"_api/web/lists/getbytitle(\'{encode(title)}\')/items({id})/roleassignments?$expand=Member/users,RoleDefinitionBindings"
+            ITEMS: f"_api/web/lists/getbytitle(\'{encode(title)}\')/items({id})/roleassignments?$expand=Member/users,RoleDefinitionBindings",
+            DRIVES: f"_api/web/lists/getbytitle(\'{encode(title)}\')/items({id})/roleassignments?$expand=Member/users,RoleDefinitionBindings"
         }
         if not rel_url.endswith("/"):
             rel_url = rel_url + "/"


### PR DESCRIPTION
Following changes have been made as a part of this PR:

- Support for drive items (files and folders)
- Support for Sub sites (sites inside a site)
- Implementation for fetching user-level permissions as an independent process
- Modified approach for multiprocessing
- Implementation for providing a single daemon process for all different functions in the connector